### PR TITLE
Fix android nullref

### DIFF
--- a/Library/RadarIO.Xamarin.Android/Conversion.cs
+++ b/Library/RadarIO.Xamarin.Android/Conversion.cs
@@ -310,11 +310,11 @@ namespace RadarIO.Xamarin
             {
                 Text = service.Text,
                 Title = service.Title,
-                Icon = (int)service.Icon,
+                Icon = service.Icon is null ? 0 : (int)service.Icon,
                 UpdatesOnly = service.UpdatesOnly,
                 Activity = service.Activity,
-                Importance = (int)service.Importance,
-                Id = (int)service.Id
+                Importance = service.Importance is null ? 0 : (int)service.Importance,
+                Id = service.Id is null ? 0 : (int)service.Id
             };
 
         internal static AndroidBinding.RadarTripOptions ToBinding(this RadarTripOptions options)

--- a/Library/RadarIO.nuspec
+++ b/Library/RadarIO.nuspec
@@ -2,7 +2,7 @@
 <package>
 	<metadata>
 		<id>RadarIO.Xamarin</id>
-		<version>3.1.4</version>
+		<version>3.2.0.1</version>
 		<title>Radar Xamarin SDK</title>
 		<authors>Radar Labs, Inc.</authors>
 		<owners>Radar Labs, Inc.</owners>


### PR DESCRIPTION
fixes a nullref from the foreground service instantiated by the continuous tracking preset on android. please upgrade to this version if you’re going to test android presets